### PR TITLE
fix: suggestion for volume mount issue

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -114,6 +114,7 @@ impl Container {
         if let Some(volumes) = &self.volumes {
             for volume in volumes {
                 dockerized.args.push(format!("-v{}", volume));
+                dockerized.args.push(volume.to_string());
             }
         }
 


### PR DESCRIPTION
i believe this should mitigate a problem i found when using `volume` for containers:

```shell
➜  .robopages robopages run --function zap_baseline_scan
>> enter value for argument 'target': https://scanme.nmap.org/

[2024-11-07T21:20:51Z WARN ] executing: /usr/local/bin/docker run --rm -v${HOME}:/zap/wrk --net=host zaproxy/zap-stable -t https://scanme.nmap.org/ zap_headless_scan
>> enter 'y' to proceed or any other key to cancel: y


EXIT CODE: exit status: 125
ERROR: docker: Error response from daemon: create ${HOME}: "${HOME}" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

please noob me if this is not the case :) i also receive the same result with `sql_map` [example](https://github.com/dreadnode/robopages/blob/b29a33dc618aa9e4aaa644a9dd00eba8b31d4b2f/cybersecurity/offensive/web-exploitation/sqlmap.yml) and is not specific to my WIP robopage