### PR TITLE
chore: do not fail serve on container pulls

### DIFF
--- a/src/runtime/docker.rs
+++ b/src/runtime/docker.rs
@@ -73,7 +73,7 @@ async fn run_command(command: &str, args: &[&str]) -> anyhow::Result<()> {
 }
 
 pub(crate) async fn pull_image(image: &str, platform: Option<String>) -> anyhow::Result<()> {
-    run_command(
+    let result = run_command(
         "sh",
         &[
             "-c",
@@ -87,7 +87,13 @@ pub(crate) async fn pull_image(image: &str, platform: Option<String>) -> anyhow:
             ),
         ],
     )
-    .await
+    .await;
+
+    if let Err(e) = result {
+        log::error!("Docker pull encountered an error: {}", e);
+    }
+
+    Ok(())
 }
 
 pub(crate) async fn build_image(name: &str, path: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
a suggestion PR as i encountered a corner case which will likely affect anyone who has either changed host machine or cleaned docker image volume (my eample) in the delta from when the prior robopage templates were verified and tested with the latest release which caused the robopages-cli server to fail `serve`'ing

i noticed a corner-case where it looks like a docker image has been gated/removed or whatever that was previously working:

```bash
➜  robopages-cli git:(main) docker pull squealer
Using default tag: latest
Error response from daemon: pull access denied for squealer, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

local testing following commit:

```bash
2025-01-31T19:17:59Z INFO ] serving 24 pages on http://127.0.0.1:8000 with 12 max running tasks

^C
➜  robopages-cli git:(ads/eng-929-chore-dont-exist-on-failed-pulled-containers) ✗ 
➜  robopages-cli git:(ads/eng-929-chore-dont-exist-on-failed-pulled-containers) ✗ cargo build
cargo install --path .
robopages serve
   Compiling robopages v0.4.0 (/Users/ads/git/robopages-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.96s
  Installing robopages v0.4.0 (/Users/ads/git/robopages-cli)
    Updating crates.io index
     Locking 401 packages to latest compatible versions
      Adding brotli v6.0.0 (latest: v7.0.0)
      Adding bzip2 v0.4.4 (latest: v0.5.0)
      Adding convert_case v0.4.0 (latest: v0.7.1)
      Adding cookie v0.16.2 (latest: v0.18.1)
      Adding core-foundation v0.9.4 (latest: v0.10.0)
      Adding crypto-bigint v0.5.5 (latest: v0.6.0)
      Adding derive_more v0.99.18 (latest: v1.0.0)
      Adding dirs v5.0.1 (latest: v6.0.0)
      Adding dirs-sys v0.4.1 (latest: v0.5.0)
      Adding foreign-types v0.3.2 (latest: v0.5.0)
      Adding foreign-types-shared v0.1.1 (latest: v0.3.1)
      Adding generic-array v0.14.7 (latest: v1.2.0)
      Adding getrandom v0.2.15 (latest: v0.3.1)
      Adding h2 v0.3.26 (latest: v0.4.7)
      Adding hermit-abi v0.3.9 (latest: v0.4.0)
      Adding http v0.2.12 (latest: v1.2.0)
      Adding itertools v0.13.0 (latest: v0.14.0)
      Adding linux-raw-sys v0.4.15 (latest: v0.7.0)
      Adding os_str_bytes v6.6.1 (latest: v7.0.0)
      Adding password-hash v0.4.2 (latest: v0.5.0)
      Adding pbkdf2 v0.11.0 (latest: v0.12.2)
      Adding rand v0.8.5 (latest: v0.9.0)
      Adding rand_chacha v0.3.1 (latest: v0.9.0)
      Adding rand_core v0.6.4 (latest: v0.9.0)
      Adding redox_users v0.4.6 (latest: v0.5.0)
      Adding russh v0.45.0 (latest: v0.50.0)
      Adding russh-cryptovec v0.7.3 (latest: v0.50.0)
      Adding russh-keys v0.45.0 (latest: v0.49.2)
      Adding security-framework v2.11.1 (latest: v3.2.0)
      Adding seize v0.3.3 (latest: v0.4.9)
      Adding thiserror v1.0.69 (latest: v2.0.11)
      Adding thiserror-impl v1.0.69 (latest: v2.0.11)
      Adding tinystr v0.7.6 (latest: v0.8.0)
      Adding wasi v0.11.0+wasi-snapshot-preview1 (latest: v0.14.0+wasi-0.2.3)
      Adding wasi v0.13.3+wasi-0.2.2 (latest: v0.14.0+wasi-0.2.3)
      Adding which v6.0.3 (latest: v7.0.1)
      Adding windows-core v0.52.0 (latest: v0.59.0)
      Adding windows-registry v0.2.0 (latest: v0.4.0)
      Adding windows-result v0.2.0 (latest: v0.3.0)
      Adding windows-strings v0.1.0 (latest: v0.3.0)
      Adding windows-sys v0.48.0 (latest: v0.59.0)
      Adding windows-sys v0.52.0 (latest: v0.59.0)
      Adding windows-targets v0.48.5 (latest: v0.53.0)
      Adding windows-targets v0.52.6 (latest: v0.53.0)
      Adding windows_aarch64_gnullvm v0.48.5 (latest: v0.53.0)
      Adding windows_aarch64_gnullvm v0.52.6 (latest: v0.53.0)
      Adding windows_aarch64_msvc v0.48.5 (latest: v0.53.0)
      Adding windows_aarch64_msvc v0.52.6 (latest: v0.53.0)
      Adding windows_i686_gnu v0.48.5 (latest: v0.53.0)
      Adding windows_i686_gnu v0.52.6 (latest: v0.53.0)
      Adding windows_i686_gnullvm v0.52.6 (latest: v0.53.0)
      Adding windows_i686_msvc v0.48.5 (latest: v0.53.0)
      Adding windows_i686_msvc v0.52.6 (latest: v0.53.0)
      Adding windows_x86_64_gnu v0.48.5 (latest: v0.53.0)
      Adding windows_x86_64_gnu v0.52.6 (latest: v0.53.0)
      Adding windows_x86_64_gnullvm v0.48.5 (latest: v0.53.0)
      Adding windows_x86_64_gnullvm v0.52.6 (latest: v0.53.0)
      Adding windows_x86_64_msvc v0.48.5 (latest: v0.53.0)
      Adding windows_x86_64_msvc v0.52.6 (latest: v0.53.0)
      Adding winsafe v0.0.19 (latest: v0.0.22)
      Adding wit-bindgen-rt v0.33.0 (latest: v0.38.0)
      Adding writeable v0.5.5 (latest: v0.6.0)
      Adding zerocopy v0.7.35 (latest: v0.8.14)
      Adding zerocopy-derive v0.7.35 (latest: v0.8.14)
      Adding zerovec v0.10.4 (latest: v0.11.0)
      Adding zerovec-derive v0.10.3 (latest: v0.11.0)
   Compiling robopages v0.4.0 (/Users/ads/git/robopages-cli)
    Finished `release` profile [optimized] target(s) in 7.74s
   Replacing /Users/ads/.cargo/bin/robopages
    Replaced package `robopages v0.4.0 (/Users/ads/git/robopages-cli)` with `robopages v0.4.0 (/Users/ads/git/robopages-cli)` (executable `robopages`)
[2025-01-31T19:19:38Z INFO ] pre building container for function squealer_scan_everything_git_repo ...
[2025-01-31T19:19:38Z INFO ] Checking for docker image: squealer:latest
[2025-01-31T19:19:38Z INFO ] Image squealer:latest not found locally, attempting pull
[2025-01-31T19:19:38Z INFO ] Error response from daemon: pull access denied for squealer, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
[2025-01-31T19:19:38Z WARN ] Failed to pull squealer:latest: command failed with status: ExitStatus(unix_wait_status(256))
[2025-01-31T19:19:38Z INFO ] pre building container for function squealer_scan_git_repo ...
[2025-01-31T19:19:38Z INFO ] Checking for docker image: squealer:latest
[2025-01-31T19:19:38Z INFO ] Image squealer:latest not found locally, attempting pull
[2025-01-31T19:19:39Z INFO ] Error response from daemon: pull access denied for squealer, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
[2025-01-31T19:19:39Z WARN ] Failed to pull squealer:latest: command failed with status: ExitStatus(unix_wait_status(256))
[2025-01-31T19:19:39Z INFO ] pre building container for function trufflehog_scan ...
[2025-01-31T19:19:39Z INFO ] Checking for docker image: trufflesecurity/trufflehog
[2025-01-31T19:19:39Z INFO ] Image trufflesecurity/trufflehog not found locally, attempting pull
[2025-01-31T19:19:39Z INFO ] Using default tag: latest
[2025-01-31T19:19:40Z INFO ] latest: Pulling from trufflesecurity/trufflehog
[2025-01-31T19:19:40Z INFO ] 52f827f72350: Already exists
[2025-01-31T19:19:40Z INFO ] ae21e8ca9bd8: Pulling fs layer
...
[2025-01-31T19:26:35Z INFO ] Digest: sha256:31f1d54c59fb1bf1b4381b13cbce89bc22449008a664987c468d103699af8c47
[2025-01-31T19:26:35Z INFO ] Status: Downloaded newer image for alpine/curl:latest
[2025-01-31T19:26:35Z INFO ] docker.io/alpine/curl:latest
[2025-01-31T19:26:35Z INFO ] pre building container for function http_post ...
[2025-01-31T19:26:35Z INFO ] serving 24 pages on http://127.0.0.1:8000 with 12 max running tasks
```

example function execution:

```bash
➜  robopages-cli git:(ads/eng-929-chore-dont-exist-on-failed-pulled-containers) ✗ robopages run -F zsc
an_default_scan
>> enter value for argument 'target': 127.0.0.1

[2025-01-31T19:29:26Z WARN ] executing: /usr/local/bin/docker run --rm -v/Users/ads/.robopages/robopages-main/cybersecurity/offensive/information-gathering:/data --net=host zscan_local -target 127.0.0.1
>> enter 'y' to proceed or any other key to cancel: y


{
  "nodes": [
    {
      "ip": "127.0.0.1",
      "ports": [
        {
          "port": 6443,
          "protocol": "http",
...
```

also verified the images are present in the container runtime library

the change proposes we log but do not fail to `serve` if a container fails for whatever reason and in most cases beyond our control