### PR TITLE
fix: Ads/eng 1353 attributeerror in rigging examplepy regarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,110 @@
-/target
+### Rust ###
+/target/
+**/*.rs.bk
+*.pdb
+Cargo.lock
+# Keep Cargo.lock for binary projects, uncomment this line if it's a library
+
+### IDE and Editors ###
+# VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# JetBrains IDEs (IntelliJ, CLion, etc.)
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+.idea_modules/
+
+# SublimeText
+*.sublime-workspace
+*.sublime-project
+
+# Mac
 .DS_Store
-.mypy_cache
-__pycache__
+.AppleDouble
+.LSOverride
+._*
 
-/.venv
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
 
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.python-version
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# pytest
+.pytest_cache/
+.coverage
+htmlcov/
+
+### Project specific ###
 # proxy stuff
 burp.cer
 burp.pem
 install_burp.py
 
-# Local working files
-hans_test.py
+# Logs
+logs/
+*.log
+npm-debug.log*
+
+# Dependencies
+node_modules/
+
+# Local config
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Build artifacts
+/dist
+/build
+
+# proxy stuff
+burp.cer
+burp.pem
+install_burp.py

--- a/examples/rigging_example.py
+++ b/examples/rigging_example.py
@@ -1,168 +1,23 @@
 import asyncio
 import os
 from loguru import logger
-import requests
 import rigging as rg
 from rigging import logging
 from rich import print
-from typing import Annotated
 
 os.environ["LOGFIRE_IGNORE_NO_CONFIG"] = "1"
 logging.configure_logging("DEBUG", None, "DEBUG")
-
-
-class RoboPagesTool(rg.Tool):
-    """Base class for RoboPages tools that are dynamically wrapped from the server"""
-
-    name = "robopages_tool"
-    description = "A tool from the RoboPages server"
-
-    def __init__(self, tool_data):
-        self.data = tool_data
-        self.name = tool_data["name"]
-        self.description = tool_data["description"]
-
-        for function in tool_data["functions"]:
-            func_name = function["name"]
-            params = function.get("parameters", [])
-
-            def make_func(f_name, f_params):
-                param_list = []
-                annotations = {"return": str}
-
-                for p in f_params:
-                    param_name = p["name"]
-                    param_desc = p.get("description", "")
-                    annotations[param_name] = Annotated[str, param_desc]
-                    param_list.append(param_name)
-
-                def dynamic_func(self, **kwargs):
-                    """Dynamically created function"""
-                    filtered_kwargs = {
-                        k: v for k, v in kwargs.items() if k in param_list
-                    }
-                    return self._call_function(f_name, filtered_kwargs)
-
-                dynamic_func.__name__ = f_name
-                dynamic_func.__annotations__ = annotations
-                dynamic_func.__doc__ = function.get("description", "")
-
-                return dynamic_func
-
-            setattr(
-                self,
-                func_name,
-                make_func(func_name, params).__get__(self, self.__class__),
-            )
-
-    def _call_function(self, func_name: str, args: dict) -> str:
-        """Call the function on the RoboPages server"""
-        print(f"Calling {self.name}.{func_name}({args})")
-
-        try:
-            response = requests.post(
-                "http://localhost:8000/process",
-                json=[
-                    {
-                        "type": "function",
-                        "function": {
-                            "name": func_name,
-                            "arguments": args,
-                        },
-                    }
-                ],
-            )
-
-            return response.json()[0]["content"]
-        except Exception as e:
-            print(f"Error calling function: {e}")
-            return f"Error: {str(e)}"
-
-
-def create_tool_class(tool_data):
-    """Create a new Tool class dynamically for a specific tool from RoboPages"""
-    tool_name = tool_data["name"]
-    tool_desc = tool_data["description"]
-
-    class_name = f"{tool_name.replace(' ', '')}Tool"
-
-    new_class = type(
-        class_name,
-        (rg.Tool,),
-        {
-            "name": tool_name,
-            "description": tool_desc,
-        },
-    )
-
-    for function in tool_data["functions"]:
-        func_name = function["name"]
-        params = function.get("parameters", [])
-
-        param_list = []
-        annotations = {"return": str}
-
-        for p in params:
-            param_name = p["name"]
-            param_desc = p.get("description", "")
-            annotations[param_name] = Annotated[str, param_desc]
-            param_list.append(param_name)
-
-        def make_function(fn_name, fn_params):
-            def dynamic_func(self, **kwargs):
-                """Dynamically created function"""
-                filtered_kwargs = {k: v for k, v in kwargs.items() if k in fn_params}
-
-                # Call the RoboPages server
-                try:
-                    response = requests.post(
-                        "http://localhost:8000/process",
-                        json=[
-                            {
-                                "type": "function",
-                                "function": {
-                                    "name": fn_name,
-                                    "arguments": filtered_kwargs,
-                                },
-                            }
-                        ],
-                    )
-                    return response.json()[0]["content"]
-                except Exception as e:
-                    print(f"Error calling function: {e}")
-                    return f"Error: {str(e)}"
-
-            dynamic_func.__name__ = fn_name
-            dynamic_func.__annotations__ = annotations
-            dynamic_func.__doc__ = function.get("description", "")
-
-            return dynamic_func
-
-        setattr(new_class, func_name, make_function(func_name, param_list))
-
-    return new_class
 
 
 async def run():
     """Main function that runs the chat with RoboPages tools"""
 
     try:
-        # Fetch tools from the RoboPages server
-        response = requests.get("http://localhost:8000/?flavor=rigging")
-        tools_data = response.json()
+        logger.info("Fetching tools from RoboPages server")
+        # Use the built-in robopages integration
+        tools = rg.integrations.robopages("http://localhost:8000")
 
-        logger.info(f"Fetched {len(tools_data)} tools from RoboPages server")
-        for tool in tools_data:
-            logger.info(f"Tool: {tool['name']} - {tool['description']}")
-            for func in tool.get("functions", []):
-                logger.info(f"  Function: {func['name']}")
-
-        tools = []
-        for tool_data in tools_data:
-            tool_class = create_tool_class(tool_data)
-            tools.append(tool_class())
-
-        logger.info(f"Created {len(tools)} tool instances")
+        logger.info(f"Fetched {len(tools)} tools from RoboPages server")
 
         prompt = """
         I need you to find all open ports on the local machine (127.0.0.1).
@@ -188,12 +43,17 @@ async def run():
         print("\n--- RESULT ---\n")
         print(chat.last.content)
 
+        return chat
+
     except Exception as e:
         logger.error(f"Error: {e}")
         import traceback
 
         traceback.print_exc()
+        return None
 
 
 if __name__ == "__main__":
-    asyncio.run(run())
+    chat = asyncio.run(run())
+    if chat:
+        print(chat.conversation)

--- a/examples/rigging_example.py
+++ b/examples/rigging_example.py
@@ -1,85 +1,199 @@
 import asyncio
+import os
+from loguru import logger
 import requests
 import rigging as rg
+from rigging import logging
 from rich import print
+from typing import Annotated
+
+os.environ["LOGFIRE_IGNORE_NO_CONFIG"] = "1"
+logging.configure_logging("DEBUG", None, "DEBUG")
 
 
-# we need to wrap the tools in a class that Rigging can understand
-class Wrapper(rg.Tool):
-    # we'll set these in the constructor
-    name = "_"
-    description = "_"
+class RoboPagesTool(rg.Tool):
+    """Base class for RoboPages tools that are dynamically wrapped from the server"""
 
-    def __init__(self, tool: dict):
-        self.tool = tool
-        self.name = tool["name"]
-        self.description = tool["description"]
+    name = "robopages_tool"
+    description = "A tool from the RoboPages server"
 
-        # declare dynamically the functions by their name
-        for function in tool["functions"]:
+    def __init__(self, tool_data):
+        self.data = tool_data
+        self.name = tool_data["name"]
+        self.description = tool_data["description"]
+
+        for function in tool_data["functions"]:
+            func_name = function["name"]
+            params = function.get("parameters", [])
+
+            def make_func(f_name, f_params):
+                param_list = []
+                annotations = {"return": str}
+
+                for p in f_params:
+                    param_name = p["name"]
+                    param_desc = p.get("description", "")
+                    annotations[param_name] = Annotated[str, param_desc]
+                    param_list.append(param_name)
+
+                def dynamic_func(self, **kwargs):
+                    """Dynamically created function"""
+                    filtered_kwargs = {
+                        k: v for k, v in kwargs.items() if k in param_list
+                    }
+                    return self._call_function(f_name, filtered_kwargs)
+
+                dynamic_func.__name__ = f_name
+                dynamic_func.__annotations__ = annotations
+                dynamic_func.__doc__ = function.get("description", "")
+
+                return dynamic_func
+
             setattr(
-                Wrapper,
-                function["name"],
-                lambda self, *args, **kwargs: self._execute_function(
-                    function["name"], *args, **kwargs
-                ),
+                self,
+                func_name,
+                make_func(func_name, params).__get__(self, self.__class__),
             )
 
-    def _execute_function(self, func_name: str, *args, **kwargs):
-        print(f"executing {self.name}.{func_name}{kwargs} ...")
-        # execute the call via robopages and return the result to Rigging
-        return requests.post(
-            "http://localhost:8000/process",
-            json=[
-                {
-                    "type": "function",
-                    "function": {
-                        "name": func_name,
-                        "arguments": kwargs,
-                    },
-                }
-            ],
-        ).json()[0]["content"]
+    def _call_function(self, func_name: str, args: dict) -> str:
+        """Call the function on the RoboPages server"""
+        print(f"Calling {self.name}.{func_name}({args})")
 
-    def get_description(self) -> rg.tool.ToolDescription:
-        """Creates a full description of the tool for use in prompting"""
+        try:
+            response = requests.post(
+                "http://localhost:8000/process",
+                json=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": func_name,
+                            "arguments": args,
+                        },
+                    }
+                ],
+            )
 
-        return rg.tool.ToolDescription(
-            name=self.name,
-            description=self.description,
-            functions=[
-                rg.tool.ToolFunction(
-                    name=function["name"],
-                    description=function["description"],
-                    parameters=[
-                        rg.tool.ToolParameter(
-                            name=param["name"],
-                            type=param["type"],
-                            description=param["description"],
-                        )
-                        for param in function["parameters"]
-                    ],
-                )
-                for function in self.tool["functions"]
-            ],
-        )
+            return response.json()[0]["content"]
+        except Exception as e:
+            print(f"Error calling function: {e}")
+            return f"Error: {str(e)}"
 
 
-async def run(model: str):
-    # get the tools from the Robopages server and wrap each function for Rigging
-    tools = [
-        Wrapper(tool)
-        for tool in requests.get("http://localhost:8000/?flavor=rigging").json()
-    ]
+def create_tool_class(tool_data):
+    """Create a new Tool class dynamically for a specific tool from RoboPages"""
+    tool_name = tool_data["name"]
+    tool_desc = tool_data["description"]
 
-    chat = (
-        await rg.get_generator(model)
-        .chat("Find open ports on 127.0.0.1")
-        .using(*tools, force=True)
-        .run()
+    class_name = f"{tool_name.replace(' ', '')}Tool"
+
+    new_class = type(
+        class_name,
+        (rg.Tool,),
+        {
+            "name": tool_name,
+            "description": tool_desc,
+        },
     )
 
-    print(chat.last.content)
+    for function in tool_data["functions"]:
+        func_name = function["name"]
+        params = function.get("parameters", [])
+
+        param_list = []
+        annotations = {"return": str}
+
+        for p in params:
+            param_name = p["name"]
+            param_desc = p.get("description", "")
+            annotations[param_name] = Annotated[str, param_desc]
+            param_list.append(param_name)
+
+        def make_function(fn_name, fn_params):
+            def dynamic_func(self, **kwargs):
+                """Dynamically created function"""
+                filtered_kwargs = {k: v for k, v in kwargs.items() if k in fn_params}
+
+                # Call the RoboPages server
+                try:
+                    response = requests.post(
+                        "http://localhost:8000/process",
+                        json=[
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": fn_name,
+                                    "arguments": filtered_kwargs,
+                                },
+                            }
+                        ],
+                    )
+                    return response.json()[0]["content"]
+                except Exception as e:
+                    print(f"Error calling function: {e}")
+                    return f"Error: {str(e)}"
+
+            dynamic_func.__name__ = fn_name
+            dynamic_func.__annotations__ = annotations
+            dynamic_func.__doc__ = function.get("description", "")
+
+            return dynamic_func
+
+        setattr(new_class, func_name, make_function(func_name, param_list))
+
+    return new_class
 
 
-asyncio.run(run("gpt-4o"))
+async def run():
+    """Main function that runs the chat with RoboPages tools"""
+
+    try:
+        # Fetch tools from the RoboPages server
+        response = requests.get("http://localhost:8000/?flavor=rigging")
+        tools_data = response.json()
+
+        logger.info(f"Fetched {len(tools_data)} tools from RoboPages server")
+        for tool in tools_data:
+            logger.info(f"Tool: {tool['name']} - {tool['description']}")
+            for func in tool.get("functions", []):
+                logger.info(f"  Function: {func['name']}")
+
+        tools = []
+        for tool_data in tools_data:
+            tool_class = create_tool_class(tool_data)
+            tools.append(tool_class())
+
+        logger.info(f"Created {len(tools)} tool instances")
+
+        prompt = """
+        I need you to find all open ports on the local machine (127.0.0.1).
+        Please use the available tools to scan the ports and provide a summary of the results.
+
+        Be thorough but concise in your analysis. Present the information in a clear format.
+
+        After scanning, list all the open ports you found and what services might be running on them.
+        """
+
+        logger.info("Starting chat with model")
+        generator = rg.get_generator("gpt-4o")
+
+        chat = await generator.chat(prompt).using(*tools, force=True).run()
+
+        logger.info("Chat completed. Full conversation:")
+        for i, message in enumerate(chat.messages):
+            logger.info(f"Message {i + 1} ({message.role}):")
+            logger.info(
+                message.content[:200] + ("..." if len(message.content) > 200 else "")
+            )
+
+        print("\n--- RESULT ---\n")
+        print(chat.last.content)
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        import traceback
+
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
this originally started as an attribute error due to an upgrade from rigging
however, to address this we cut a new release with a native robopages tool on 2.3.0 -> https://pypi.org/project/rigging/2.3.0/
therefore, this fix addresses the rigging example in this repo, but using the native tool integration

example usage:

```bash
python examples/rigging_example.py
```

<img width="1363" alt="image" src="https://github.com/user-attachments/assets/95c1aa36-6373-4c95-a1c2-aa08b172bfce" />

etc

<img width="798" alt="image" src="https://github.com/user-attachments/assets/3222b7d4-8c73-4883-9a1b-f6ae9eb25981" />
