### PR TITLE
Replace Only Placeholder

### DIFF
--- a/src/book/runtime.rs
+++ b/src/book/runtime.rs
@@ -198,9 +198,10 @@ impl<'a> FunctionRef<'a> {
                         .map_err(|e| anyhow!(e))?
                         .as_str();
                     let var_default = caps.get(3).map(|m| m.as_str());
+                    let full_match = caps.get(0).unwrap().as_str();
 
                     // read variable from the environment if the name starts with env. or ENV.
-                    if var_name.starts_with("env.") || var_name.starts_with("ENV.") {
+                    let replacement_value = if var_name.starts_with("env.") || var_name.starts_with("ENV.") {
                         let env_var_name = var_name.replace("env.", "").replace("ENV.", "");
                         let env_var = std::env::var(&env_var_name);
                         let env_var_value = if let Ok(value) = env_var {
@@ -235,7 +236,10 @@ impl<'a> FunctionRef<'a> {
                         default_value.to_string()
                     } else {
                         return Err(anyhow::anyhow!("argument {} not provided", var_name));
-                    }
+                    };
+                    
+                    // Replace only the pattern within the argument
+                    arg.replace(full_match, &replacement_value)
                 } else {
                     arg
                 });


### PR DESCRIPTION
# Replace Only Placeholder

**Key Changes:**

- [x] Replace only the placeholder instead of the entire argument.

The biggest change is to only replace the place holder instead of the entire line of an argument. For example if the placeholder is ${target} the current code will replace the entire line that the pattern is found. My proposition is that only the placeholder be replaced. 

This change allows for using that in other parts of an argument such as a tool's output. Since in the output you need to specify the location /data/example-output.txt. If you use the ${target} inside of that output, it will wipe out everything you put on that line and just have the result of ${target} 

Let's say ${target} == google.com and you want to have the output of a tool be saved as tool-google.com.txt. You would put in the cmdline arguments section of the yml file. `-o /data/tool-${target}.txt`. This will currently output `google.com`. You lose the `-o /data/tool-` with the current way robopages-cli replaces the text. 