### PR TITLE
fix: interpolated domain string bug in robopage function

### DIFF
--- a/src/book/runtime.rs
+++ b/src/book/runtime.rs
@@ -187,62 +187,71 @@ impl<'a> FunctionRef<'a> {
         let command_line = self.function.execution.get_command_line()?;
         let mut env = BTreeMap::new();
 
-        // interpolate the arguments
-        let command_line = {
-            let mut interpolated = Vec::new();
-            for arg in command_line {
-                interpolated.push(if let Some(caps) = ARG_VALUE_PARSER.captures(&arg) {
-                    let var_name = caps
-                        .get(1)
-                        .ok_or(ARG_EXPRESSION_ERROR)
-                        .map_err(|e| anyhow!(e))?
-                        .as_str();
-                    let var_default = caps.get(3).map(|m| m.as_str());
+// interpolate the arguments
+let command_line = {
+    let mut interpolated = Vec::new();
+    for arg in command_line {
+        if ARG_VALUE_PARSER.is_match(&arg) {
+            // Process args with placeholders by replacing only the matched patterns
+            let mut processed_arg = arg.clone();
 
-                    // read variable from the environment if the name starts with env. or ENV.
-                    if var_name.starts_with("env.") || var_name.starts_with("ENV.") {
-                        let env_var_name = var_name.replace("env.", "").replace("ENV.", "");
-                        let env_var = std::env::var(&env_var_name);
-                        let env_var_value = if let Ok(value) = env_var {
-                            value
-                        } else if let Some(def) = var_default {
+            // Find all matches and collect the replacements
+            let mut replacements = Vec::new();
+            for caps in ARG_VALUE_PARSER.captures_iter(&arg) {
+                let full_match = caps.get(0).unwrap().as_str();
+                let var_name = caps.get(1).ok_or(ARG_EXPRESSION_ERROR).map_err(|e| anyhow!(e))?.as_str();
+                let var_default = caps.get(3).map(|m| m.as_str());
+
+                let replacement = if var_name.starts_with("env.") || var_name.starts_with("ENV.") {
+                    let env_var_name = var_name.replace("env.", "").replace("ENV.", "");
+                    let env_var = std::env::var(&env_var_name);
+                    let env_var_value = if let Ok(value) = env_var {
+                        value
+                    } else if let Some(def) = var_default {
+                        def.to_string()
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "environment variable {} not set",
+                            env_var_name
+                        ));
+                    };
+
+                    // add the environment variable to the command line for later use
+                    env.insert(env_var_name, env_var_value.to_owned());
+
+                    env_var_value
+                } else if let Some(value) = arguments.get(var_name) {
+                    if value.is_empty() {
+                        if let Some(def) = var_default {
                             def.to_string()
                         } else {
-                            return Err(anyhow::anyhow!(
-                                "environment variable {} not set",
-                                env_var_name
-                            ));
-                        };
-
-                        // add the environment variable to the command line for later use
-                        env.insert(env_var_name, env_var_value.to_owned());
-
-                        env_var_value
-                    } else if let Some(value) = arguments.get(var_name) {
-                        // if the value is empty and there's a default value, use the default value
-                        if value.is_empty() {
-                            if let Some(def) = var_default {
-                                def.to_string()
-                            } else {
-                                value.to_string()
-                            }
-                        } else {
-                            // otherwise, use the provided value
                             value.to_string()
                         }
-                    } else if let Some(default_value) = var_default {
-                        // if the value is not provided and there's a default value, use the default value
-                        default_value.to_string()
                     } else {
-                        return Err(anyhow::anyhow!("argument {} not provided", var_name));
+                        value.to_string()
                     }
+                } else if let Some(default_value) = var_default {
+                    default_value.to_string()
                 } else {
-                    arg
-                });
-            }
-            interpolated
-        };
+                    return Err(anyhow::anyhow!("argument {} not provided", var_name));
+                };
 
+                replacements.push((full_match, replacement));
+            }
+
+            // Apply all replacements to the arg string
+            for (pattern, replacement) in replacements {
+                processed_arg = processed_arg.replace(pattern, &replacement);
+            }
+
+            interpolated.push(processed_arg);
+        } else {
+            // For args without placeholders, use as-is
+            interpolated.push(arg);
+        }
+    }
+    interpolated
+};
         // final parsing
         CommandLine::from_vec_with_env(&command_line, env)
     }

--- a/src/book/runtime.rs
+++ b/src/book/runtime.rs
@@ -187,75 +187,75 @@ impl<'a> FunctionRef<'a> {
         let command_line = self.function.execution.get_command_line()?;
         let mut env = BTreeMap::new();
 
-// interpolate the arguments
-let command_line = {
-    let mut interpolated = Vec::new();
-    for arg in command_line {
-        if ARG_VALUE_PARSER.is_match(&arg) {
-            // Process args with placeholders by replacing only the matched patterns
-            let mut processed_arg = arg.clone();
+    // interpolate the arguments
+    let command_line = {
+        let mut interpolated = Vec::new();
+        for arg in command_line {
+            if ARG_VALUE_PARSER.is_match(&arg) {
+                // Process args with placeholders by replacing only the matched     patterns
+                let mut processed_arg = arg.clone();
 
-            // Find all matches and collect the replacements
-            let mut replacements = Vec::new();
-            for caps in ARG_VALUE_PARSER.captures_iter(&arg) {
-                let full_match = caps.get(0).unwrap().as_str();
-                let var_name = caps.get(1).ok_or(ARG_EXPRESSION_ERROR).map_err(|e| anyhow!(e))?.as_str();
-                let var_default = caps.get(3).map(|m| m.as_str());
+                // Find all matches and collect the replacements
+                let mut replacements = Vec::new();
+                for caps in ARG_VALUE_PARSER.captures_iter(&arg) {
+                    let full_match = caps.get(0).unwrap().as_str();
+                    let var_name = caps.get(1).ok_or(ARG_EXPRESSION_ERROR).map_err(|    e| anyhow!(e))?.as_str();
+                    let var_default = caps.get(3).map(|m| m.as_str());
 
-                let replacement = if var_name.starts_with("env.") || var_name.starts_with("ENV.") {
-                    let env_var_name = var_name.replace("env.", "").replace("ENV.", "");
-                    let env_var = std::env::var(&env_var_name);
-                    let env_var_value = if let Ok(value) = env_var {
-                        value
-                    } else if let Some(def) = var_default {
-                        def.to_string()
-                    } else {
-                        return Err(anyhow::anyhow!(
-                            "environment variable {} not set",
-                            env_var_name
-                        ));
-                    };
-
-                    // add the environment variable to the command line for later use
-                    env.insert(env_var_name, env_var_value.to_owned());
-
-                    env_var_value
-                } else if let Some(value) = arguments.get(var_name) {
-                    if value.is_empty() {
-                        if let Some(def) = var_default {
+                    let replacement = if var_name.starts_with("env.") || var_name.  starts_with("ENV.") {
+                        let env_var_name = var_name.replace("env.", "").replace ("ENV.", "");
+                        let env_var = std::env::var(&env_var_name);
+                        let env_var_value = if let Ok(value) = env_var {
+                            value
+                        } else if let Some(def) = var_default {
                             def.to_string()
+                        } else {
+                            return Err(anyhow::anyhow!(
+                                "environment variable {} not set",
+                                env_var_name
+                            ));
+                        };
+
+                        // add the environment variable to the command line for     later use
+                        env.insert(env_var_name, env_var_value.to_owned());
+
+                        env_var_value
+                    } else if let Some(value) = arguments.get(var_name) {
+                        if value.is_empty() {
+                            if let Some(def) = var_default {
+                                def.to_string()
+                            } else {
+                                value.to_string()
+                            }
                         } else {
                             value.to_string()
                         }
+                    } else if let Some(default_value) = var_default {
+                        default_value.to_string()
                     } else {
-                        value.to_string()
-                    }
-                } else if let Some(default_value) = var_default {
-                    default_value.to_string()
-                } else {
-                    return Err(anyhow::anyhow!("argument {} not provided", var_name));
-                };
+                        return Err(anyhow::anyhow!("argument {} not provided",  var_name));
+                    };
 
-                replacements.push((full_match, replacement));
+                    replacements.push((full_match, replacement));
+                }
+
+                // Apply all replacements to the arg string
+                for (pattern, replacement) in replacements {
+                    processed_arg = processed_arg.replace(pattern, &replacement);
+                }
+
+                interpolated.push(processed_arg);
+            } else {
+                // For args without placeholders, use as-is
+                interpolated.push(arg);
             }
-
-            // Apply all replacements to the arg string
-            for (pattern, replacement) in replacements {
-                processed_arg = processed_arg.replace(pattern, &replacement);
-            }
-
-            interpolated.push(processed_arg);
-        } else {
-            // For args without placeholders, use as-is
-            interpolated.push(arg);
+        }
+        interpolated
+    };
+            // final parsing
+            CommandLine::from_vec_with_env(&command_line, env)
         }
     }
-    interpolated
-};
-        // final parsing
-        CommandLine::from_vec_with_env(&command_line, env)
-    }
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# fix: interpolated domain string bug in robopage function #28

closes https://github.com/dreadnode/robopages-cli/issues/27
relates to https://github.com/dreadnode/robopages/pull/36

**Key Changes:**

- [ ] fixes interpolated domain string bug in robopage function

**Changed:**

Instead of completely replacing the argument with the interpolated value, this code:

Preserves the original argument structure
Only replaces the `${...}` placeholder patterns within the argument string

The approach:

- First checks if the argument contains any placeholders
- For each placeholder match, determines the replacement value
- Collects all replacements in a vector
- Applies all replacements to the original string using replace()
- This allows placeholders to be:
    - In the middle of arguments (-o file-${target}.txt)
    - Multiple placeholders in one argument (${prefix}-${name}.${ext})
    - Mixed with fixed text
    - The original functionality is maintained, but with more flexible interpolation.

# testing

`cargo build --release` on test branch

robopage -> https://github.com/dreadnode/robopages/pull/36

```yml
description: >
  subfinder is a subdomain discovery tool that returns valid subdomains for websites, using passive online sources. It has a simple, modular architecture and is optimized for speed. subfinder is built for doing one thing only - passive subdomain enumeration, and it does that very well.

functions:
  subfinder_enum_host_subdomains:
    description: Enumerate subdomains of a target host.
    parameters:
      target:
        type: string
        description: The domain name to enumerate subdomains for.
        examples:
          - example.com
          - www.example.com

    container:
      image: projectdiscovery/subfinder
      args:
        - --net=host
      volumes:
        - ${cwd}:/data

    cmdline:
      - subfinder
      - -d
      - ${target}
      - -recursive
      - -all
      - -o
      - /data/${target}.subdomains.txt
```

```bash
./target/release/robopages run --function subfinder_enum_host_subdomains

>> enter value for argument 'target': google.com

[2025-05-02T14:26:18Z WARN ] executing: /usr/local/bin/docker run --rm -v/Users/ads/.robopages/robopages-main/cybersecurity/offensive/information-gathering:/data --net=host projectdiscovery/subfinder -d google.com -recursive -all -o /data/google.com.subdomains.txt
>> enter 'y' to proceed or any other key to cancel: y


.. <redacted>

               __    _____           __
   _______  __/ /_  / __(_)___  ____/ /__  _____
  / ___/ / / / __ \/ /_/ / __ \/ __  / _ \/ ___/
 (__  ) /_/ / /_/ / __/ / / / / /_/ /  __/ /
/____/\__,_/_.___/_/ /_/_/ /_/\__,_/\___/_/

                projectdiscovery.io

[INF] Current subfinder version v2.7.0 (outdated)
[INF] Loading provider config from /root/.config/subfinder/provider-config.yaml
[INF] Enumerating subdomains for google.com
[INF] Found 810 subdomains for google.com in 12 seconds 792 milliseconds
```