### PR TITLE
chore: add renovate bot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,34 @@
+{
+    $schema: "https://docs.renovatebot.com/renovate-schema.json",
+    extends: [
+      "config:base",
+      ":disableRateLimiting",
+      ":dependencyDashboard",
+      ":semanticCommits",
+      ":automergeDigest",
+      ":automergeBranch",
+    ],
+    dependencyDashboardTitle: "Renovate Dashboard 🤖",
+    suppressNotifications: ["prIgnoreNotification"],
+    rebaseWhen: "conflicted",
+    commitBodyTable: true,
+    cargo: {
+      commitMessageTopic: "Rust crate {{depName}}",
+    },
+    packageRules: [
+      {
+        description: "Auto merge non-major updates",
+        matchUpdateTypes: ["minor", "patch"],
+        automerge: true,
+        automergeType: "pr",
+      },
+      {
+        description: "Group Rust dev dependencies",
+        matchManagers: ["cargo"],
+        matchDepTypes: ["dev-dependencies"],
+        groupName: "Rust dev dependencies",
+        groupSlug: "rust-dev",
+      },
+    ],
+    ignorePaths: [],
+  }

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,87 @@
+---
+name: Renovate
+on:
+  # checkov:skip=CKV_GHA_7: "Workflow dispatch inputs are required for manual debugging and configuration"
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: Dry Run
+        default: "false"
+        required: false
+      logLevel:
+        description: Log Level
+        default: "debug"
+        required: false
+      version:
+        description: Renovate version
+        default: latest
+        required: false
+  schedule:
+    # Run every week on sunday and wednesday at 00:00 UTC
+    - cron: "0 0 * * 0,3"
+  push:
+    branches: ["main"]
+    paths:
+      - .github/renovate.json5
+      - .github/renovate/**.json5
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_number || github.ref }}
+  cancel-in-progress: true
+
+# Retrieve BOT_USER_ID via `curl -s "https://api.github.com/users/${BOT_USERNAME}%5Bbot%5D" | jq .id`
+env:
+  WORKFLOW_DRY_RUN: false
+  WORKFLOW_LOG_LEVEL: debug
+  WORKFLOW_VERSION: latest # 37.59.8
+  RENOVATE_PLATFORM: github
+  RENOVATE_PLATFORM_COMMIT: true
+  RENOVATE_ONBOARDING_CONFIG_FILE_NAME: .github/renovate.json5
+  RENOVATE_AUTODISCOVER: true
+  RENOVATE_AUTODISCOVER_FILTER: "${{ github.repository }}"
+  RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: app-token
+        with:
+          app-id: "${{ secrets.BOT_APP_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: "${{ steps.app-token.outputs.token }}"
+
+      - name: Override default config from dispatch variables
+        run: |
+          echo "RENOVATE_DRY_RUN=${{ github.event.inputs.dryRun || env.WORKFLOW_DRY_RUN }}" >> "${GITHUB_ENV}"
+          echo "LOG_LEVEL=${{ github.event.inputs.logLevel || env.WORKFLOW_LOG_LEVEL }}" >> "${GITHUB_ENV}"
+
+      - name: Delete old dashboard
+        run: |
+          ISSUE_NUMBER=$(gh issue list -S 'Renovate Dashboard 🤖' --json number -q '.[0].number')
+          if [ "$ISSUE_NUMBER" != "null" ] && [ -n "$ISSUE_NUMBER" ]; then
+            gh issue close "$ISSUE_NUMBER"
+          else
+            echo "No issue found to close."
+          fi
+        env:
+          GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
+
+      - name: Renovate
+        uses: renovatebot/github-action@248bf5a619694187930adc80b9343c37761c173f # v43.0.1
+        with:
+          configurationFile: "${{ env.RENOVATE_ONBOARDING_CONFIG_FILE_NAME }}"
+          token: "${{ steps.app-token.outputs.token }}"
+          renovate-version: "${{ github.event.inputs.version || env.WORKFLOW_VERSION }}"


### PR DESCRIPTION
# renovate bot

**Key Changes:**

- [ ] adds renovate bot to the repo
- [ ] disabled dependabot security updates

**Added:**

- [ ] adds renovate bot to the repo

**Removed:**

- [ ] disabled dependabot security updates


---

## Generated Summary:

Summary of changes made to set up Renovate for dependency management.

- Added a Renovate configuration file (`renovate.json5`) to define auto-update behaviors for dependencies.
- Configured the Renovate workflow (`renovate.yaml`) to run on a schedule and support manual triggers.
- Enabled automatic merging of non-major updates and grouping for Rust development dependencies.
- Established GitHub Actions permissions for the Renovate bot to manage issues and pull requests.
- Set environment variables for the Renovate workflow, ensuring correct operation with a GitHub App token.
- Includes a mechanism to delete the old Renovate dashboard issue before creating a new one.

These changes improve dependency management automation and allow for better version control in the project.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)


<!-- Delete any sections that are not applicable -->
<!-- Add screenshots or code examples if relevant -->
